### PR TITLE
Update brew command

### DIFF
--- a/native-applications.html
+++ b/native-applications.html
@@ -13,7 +13,7 @@ description: OnChrome needs a native application to connect to Chrome. Download 
     <p class="stacks-copy">Install the extension from the <a href="https://addons.mozilla.org/en-US/firefox/addon/onchrome/">Firefox add-on store</a>.</p>
 
     {% header h3 | macOS %}
-    <p class="stacks-copy">If you use homebrew, you can run <span class="ff-mono">brew cask install g3rv4/install/onchrome</span></p>
+    <p class="stacks-copy">If you use homebrew, you can run <span class="ff-mono">brew install g3rv4/install/onchrome --cask</span></p>
     <p class="stacks-copy">If you don't, download and install <a href="https://files-onchrome.gervas.io/deploy/1.0.0/macOS/OnChrome.pkg" class="js-anchor">OnChrome.pkg</a>.</p>
     {% header h3 | Windows %}
     <p class="stacks-copy">If you use chocolatey, you can run <span class="ff-mono">choco install onchrome</span></p>


### PR DESCRIPTION
Got message from latest version of brew: 

```
"Error: `brew cask` is no longer a `brew` command. Use `brew <command> --cask` instead."
```

updated the documentation to reflect this brew change